### PR TITLE
UDX-8888_Pilot_link_controller_config_change

### DIFF
--- a/helm_pkg/pilot-link-ctrlr/templates/pilot_link_ctrlr.yaml
+++ b/helm_pkg/pilot-link-ctrlr/templates/pilot_link_ctrlr.yaml
@@ -113,6 +113,9 @@ spec:
         - name: {{ .Values.pilotlinkctrlr.pvc.hostdev.name }}
           persistentVolumeClaim:
             claimName: {{ .Values.pilotlinkctrlr.pvc.hostdev.name }}
+        - name: {{ .Values.pilotlinkctrlr.pvc.hostboot.name }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.pilotlinkctrlr.pvc.hostboot.name }}
         - name: {{ .Values.pilotlinkctrlr.pvc.hostsys.name }}
           persistentVolumeClaim:
             claimName: {{ .Values.pilotlinkctrlr.pvc.hostsys.name }}
@@ -154,6 +157,9 @@ spec:
               mountPropagation: Bidirectional
             - name: {{ .Values.pilotlinkctrlr.pvc.hostdev.name }}
               mountPath: /hostdev
+              mountPropagation: HostToContainer
+            - name: {{ .Values.pilotlinkctrlr.pvc.hostboot.name }}
+              mountPath: /hostboot
               mountPropagation: HostToContainer
             - name: {{ .Values.pilotlinkctrlr.pvc.hostsys.name }}
               mountPath: /hostsys

--- a/helm_pkg/pilot-link-ctrlr/templates/pilot_link_ctrlr_storage.yaml
+++ b/helm_pkg/pilot-link-ctrlr/templates/pilot_link_ctrlr_storage.yaml
@@ -35,6 +35,22 @@ spec:
 apiVersion: v1
 kind: PersistentVolume
 metadata:
+  name: {{ printf "%s-%s" .Values.namespace .Values.pilotlinkctrlr.pv.hostboot.name }}
+  labels:
+    type: local
+spec:
+  storageClassName: manual
+  capacity:
+    storage: 1Gi
+  accessModes:
+    - ReadOnlyMany
+  volumeMode: Filesystem
+  hostPath:
+    path: /boot
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
   name: {{ printf "%s-%s" .Values.namespace .Values.pilotlinkctrlr.pv.hostsys.name }}
   labels:
     type: local
@@ -77,6 +93,21 @@ spec:
       storage: 1Gi
   storageClassName: manual
   volumeName: {{ printf "%s-%s" .Values.namespace .Values.pilotlinkctrlr.pv.hostdev.name }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Values.pilotlinkctrlr.pvc.hostboot.name }}
+  namespace: {{ .Values.namespace }}
+spec:
+  accessModes:
+    - ReadOnlyMany
+  volumeMode: Filesystem
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: manual
+  volumeName: {{ printf "%s-%s" .Values.namespace .Values.pilotlinkctrlr.pv.hostboot.name }}
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/helm_pkg/pilot-link-ctrlr/values.yaml
+++ b/helm_pkg/pilot-link-ctrlr/values.yaml
@@ -27,6 +27,8 @@ pilotlinkctrlr:
             hostpath: /mnt/pilot-link/storage
         hostdev:
             name: pilot-link-ctrlr-hostdev
+        hostboot:
+            name: pilot-link-ctrlr-hostboot
         hostsys:
             name: pilot-link-ctrlr-hostsys
     pvc:
@@ -35,6 +37,8 @@ pilotlinkctrlr:
             storage: 1Gi
         hostdev:
             name: pilot-link-ctrlr-hostdev
+        hostboot:
+            name: pilot-link-ctrlr-hostboot
         hostsys:
             name: pilot-link-ctrlr-hostsys
     dataservices:

--- a/version.yml
+++ b/version.yml
@@ -5,7 +5,7 @@ udsdeploy:
   revision:
     major: 1
     minor: 0
-    subminor: 2
+    subminor: 3
   qualifier:
     - development
   created_timestamp:


### PR DESCRIPTION
Changed config for pilot link controller to include host's boot folder in volume mounts, allows us to use the volume to evaluate where boot location is during storage detection so we can avoid trying to mount the boot device. Changes go hand in hand with https://github.com/Seagate/uds-ctrlr-k8s/pull/1